### PR TITLE
Fix potential issue with storing an NSArray into a NSMutableArray ivar

### DIFF
--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -46,7 +46,7 @@
 
 - (id)initWithSectionTitles:(NSArray*)array {
 	
-	titlesArray = [array retain];
+	titlesArray = [array mutableCopy];
 	
 	self = [super initWithFrame:CGRectZero];
 	self.backgroundColor = [UIColor clearColor];


### PR DESCRIPTION
Future compilers flag this up as a warning. It's probably not best to store as a different type from what is declared. :)
