### PR TITLE
SVSegmentedControl should be a subclass of UIControl instead of UIView

### DIFF
--- a/Demo/Classes/ViewController.h
+++ b/Demo/Classes/ViewController.h
@@ -10,9 +10,11 @@
 
 #import "SVSegmentedControl.h"
 
-@interface ViewController : UIViewController <SVSegmentedControlDelegate> {
+@interface ViewController : UIViewController {
 
 }
+
+- (void)segmentedControlChangedValue:(SVSegmentedControl*)segmentedControl;
 
 @end
 

--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -19,7 +19,7 @@
 	// 1st CONTROL
 	
 	SVSegmentedControl *navSC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Section 1", @"Section 2", nil]];
-	navSC.delegate = self;
+    [navSC addTarget:self action:@selector(segmentedControlChangedValue:) forControlEvents:UIControlEventValueChanged];
 
 	[self.view addSubview:navSC];
 	[navSC release];
@@ -30,7 +30,7 @@
 	// 2nd CONTROL
 	
 	SVSegmentedControl *redSC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"About", @"Help", @"Credits", nil]];
-	redSC.delegate = self;
+    [redSC addTarget:self action:@selector(segmentedControlChangedValue:) forControlEvents:UIControlEventValueChanged];
 	
 	redSC.crossFadeLabelsOnDrag = YES;
 	redSC.thumb.tintColor = [UIColor colorWithRed:0.6 green:0.2 blue:0.2 alpha:1];
@@ -97,9 +97,8 @@
 #pragma mark -
 #pragma mark SPSegmentedControl
 
-- (void)segmentedControl:(SVSegmentedControl*)segmentedControl didSelectIndex:(NSUInteger)index {
-	
-	NSLog(@"segmentedControl %i did select index %i (captured via delegate method)", segmentedControl.tag, index);
+- (void)segmentedControlChangedValue:(SVSegmentedControl*)segmentedControl {
+	NSLog(@"segmentedControl %i did select index %i (captured via delegate method)", segmentedControl.tag, segmentedControl.selectedIndex);
 }
 
 /*

--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -12,7 +12,7 @@
 
 @protocol SVSegmentedControlDelegate;
 
-@interface SVSegmentedControl : UIView {
+@interface SVSegmentedControl : UIControl {
 	SVSegmentedThumb *thumb;
 	CGRect thumbRects[5];
 	NSUInteger snapToIndex;

--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -7,10 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-
 #import "SVSegmentedThumb.h"
-
-@protocol SVSegmentedControlDelegate;
 
 @interface SVSegmentedControl : UIControl {
 	SVSegmentedThumb *thumb;
@@ -23,7 +20,6 @@
 	CGFloat segmentWidth;
 }
 
-@property (nonatomic, assign) id<SVSegmentedControlDelegate> delegate;
 @property (nonatomic, copy) void (^selectedSegmentChangedHandler)(id sender);
 
 @property (nonatomic, readonly) SVSegmentedThumb *thumb;
@@ -39,12 +35,5 @@
 
 - (SVSegmentedControl*)initWithSectionTitles:(NSArray*)titlesArray;
 - (void)moveThumbToIndex:(NSUInteger)segmentIndex animate:(BOOL)animate;
-
-@end
-
-
-@protocol SVSegmentedControlDelegate
-
-- (void)segmentedControl:(SVSegmentedControl*)segmentedControl didSelectIndex:(NSUInteger)index;
 
 @end

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -44,26 +44,25 @@
 }
 
 - (id)initWithSectionTitles:(NSArray*)array {
-	
-	titlesArray = [array mutableCopy];
-	
-	self = [super initWithFrame:CGRectZero];
-	self.backgroundColor = [UIColor clearColor];
-	self.clipsToBounds = YES;
-	self.userInteractionEnabled = YES;
-	
-	self.font = [UIFont boldSystemFontOfSize:15];
-	self.textColor = [UIColor grayColor];
-	self.shadowColor = [UIColor blackColor];
-	self.shadowOffset = CGSizeMake(0, -1);
-	
-	self.segmentPadding = 10.0;
-	self.height = 32.0;
-	
-	self.selectedIndex = 0;
-	
-	thumb = [[SVSegmentedThumb alloc] initWithFrame:CGRectZero];
-
+	if (self = [super initWithFrame:CGRectZero]) {
+        titlesArray = [array mutableCopy];
+        
+        self.backgroundColor = [UIColor clearColor];
+        self.clipsToBounds = YES;
+        self.userInteractionEnabled = YES;
+        
+        self.font = [UIFont boldSystemFontOfSize:15];
+        self.textColor = [UIColor grayColor];
+        self.shadowColor = [UIColor blackColor];
+        self.shadowOffset = CGSizeMake(0, -1);
+        
+        self.segmentPadding = 10.0;
+        self.height = 32.0;
+        
+        self.selectedIndex = 0;
+        
+        thumb = [[SVSegmentedThumb alloc] initWithFrame:CGRectZero];
+    }
 	return self;
 }
 

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -25,7 +25,7 @@
 
 @implementation SVSegmentedControl
 
-@synthesize delegate, selectedSegmentChangedHandler, selectedIndex, thumb;
+@synthesize selectedSegmentChangedHandler, selectedIndex, thumb;
 @synthesize font, textColor, shadowColor, shadowOffset, segmentPadding, height, crossFadeLabelsOnDrag;
 
 #pragma mark -
@@ -35,7 +35,6 @@
 	
 	[titlesArray release];
 	
-	self.delegate = nil;
 	self.selectedSegmentChangedHandler = nil;
 	self.font = nil;
 	self.textColor = nil;
@@ -297,8 +296,7 @@
 	self.selectedIndex = floor(self.thumb.center.x/segmentWidth);
 	self.thumb.title = [titlesArray objectAtIndex:self.selectedIndex];
     
-	if ([(id)self.delegate respondsToSelector:@selector(segmentedControl:didSelectIndex:)])
-		[self.delegate segmentedControl:self didSelectIndex:selectedIndex];
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
 	
 	if (self.selectedSegmentChangedHandler)
 		self.selectedSegmentChangedHandler(self);

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -156,32 +156,32 @@
 }
 
 #pragma mark -
-#pragma mark Touch
+#pragma mark Tracking
 
-- (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
-	
-	CGPoint cPos = [[touches anyObject] locationInView:self.thumb];
+- (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    [super beginTrackingWithTouch:touch withEvent:event];
+    
+    CGPoint cPos = [touch locationInView:self.thumb];
 	activated = NO;
 	
 	snapToIndex = floor(self.thumb.center.x/segmentWidth);
 	
 	if(CGRectContainsPoint(self.thumb.bounds, cPos)) {
 		tracking = YES;
-
+        
 		if (!self.crossFadeLabelsOnDrag)
 			[self.thumb deactivate];
-	
+        
 		dragOffset = (self.thumb.frame.size.width/2)-cPos.x;
-		return;
 	}
+    
+    return YES;
 }
 
-- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
-	
-	if(!tracking)
-		return;
-	
-	CGPoint cPos = [[touches anyObject] locationInView:self];
+- (BOOL)continueTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    [super continueTrackingWithTouch:touch withEvent:event];
+    
+    CGPoint cPos = [touch locationInView:self];
 	CGFloat newPos = cPos.x+dragOffset;
 	CGFloat newMaxX = newPos+(CGRectGetWidth(self.thumb.frame)/2);
 	CGFloat newMinX = newPos-(CGRectGetWidth(self.thumb.frame)/2);
@@ -193,25 +193,26 @@
 	if(newMaxX > pMaxX || newMinX < pMinX) {
 		snapToIndex = floor(self.thumb.center.x/segmentWidth);
 		[self snap:NO];
-
+        
 		if (self.crossFadeLabelsOnDrag)
 			[self updateTitles];
-		return;
 	}
 	
 	else if(tracking) {
 		self.thumb.center = CGPointMake(cPos.x+dragOffset, self.thumb.center.y);
 		moved = YES;
-
+        
 		if (self.crossFadeLabelsOnDrag)
 			[self updateTitles];
 	}
+    
+    return YES;
 }
 
-
-- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
-	
-	CGPoint cPos = [[touches anyObject] locationInView:self];
+- (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    [super endTrackingWithTouch:touch withEvent:event];
+    
+    CGPoint cPos = [touch locationInView:self];
 	CGFloat pMaxX = CGRectGetMaxX(self.bounds);
 	CGFloat pMinX = CGRectGetMinX(self.bounds);
 	
@@ -230,10 +231,10 @@
 		[self activate];
 }
 
-
-- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
-	
-	if(tracking)
+- (void)cancelTrackingWithEvent:(UIEvent *)event {
+    [super cancelTrackingWithEvent:event];
+    
+    if(tracking)
 		[self snap:NO];
 }
 
@@ -295,7 +296,7 @@
 	
 	self.selectedIndex = floor(self.thumb.center.x/segmentWidth);
 	self.thumb.title = [titlesArray objectAtIndex:self.selectedIndex];
-
+    
 	if ([(id)self.delegate respondsToSelector:@selector(segmentedControl:didSelectIndex:)])
 		[self.delegate segmentedControl:self didSelectIndex:selectedIndex];
 	


### PR DESCRIPTION
I think SVSegmentedControl should rather be a subclass of UIControl instead of UIView (like UISwitch and UISegmentControl are). This adds some benefits like not being restricted to only one delegate anymore or having control over other Events any UIControl handles.
