### PR TITLE
Fixed label fading oddity when rapidly toggling a control

### DIFF
--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -403,7 +403,9 @@
 								 [self updateTitles];
 						 }
 						 completion:^(BOOL finished){
-							 [self activate];
+                             if (finished) {
+                                 [self activate];
+                             }
 						 }];
 	}
 	


### PR DESCRIPTION
If you toggle a 2 section segmented control rapidly, the section label activates prematurely.
