### PR TITLE
Add the option to deactivate the UISwitch-like behavior

### DIFF
--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -44,7 +44,8 @@
 	
 	// 3rd CONTROL
 	
-	SVSegmentedControl *grayRC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Section 1", @"Section 2", nil]];
+	SVSegmentedControl *grayRC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"1 - No switch", @"2 - No switch", nil]];
+	grayRC.switchBehaviour = NO;
     [grayRC addTarget:self action:@selector(segmentedControlChangedValue:) forControlEvents:UIControlEventValueChanged];
 
 	grayRC.font = [UIFont boldSystemFontOfSize:19];

--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -22,6 +22,7 @@
 @property (nonatomic, readwrite) NSUInteger selectedIndex; // default is 0
 @property (nonatomic, readwrite) BOOL animateToInitialSelection; // default is NO
 @property (nonatomic, readwrite) BOOL crossFadeLabelsOnDrag; // default is NO
+@property (nonatomic, readwrite) BOOL switchBehaviour; // default is YES
 
 @property (nonatomic, strong) UIColor *tintColor; // default is [UIColor grayColor]
 @property (nonatomic, strong) UIImage *backgroundImage; // default is nil

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -56,7 +56,7 @@
 @implementation SVSegmentedControl
 
 @synthesize selectedSegmentChangedHandler, changeHandler, selectedIndex, animateToInitialSelection, accessibilityElements;
-@synthesize cornerRadius, tintColor, backgroundImage, font, textColor, textShadowColor, textShadowOffset, segmentPadding, titleEdgeInsets, height, crossFadeLabelsOnDrag;
+@synthesize cornerRadius, tintColor, backgroundImage, font, textColor, textShadowColor, textShadowOffset, segmentPadding, titleEdgeInsets, height, crossFadeLabelsOnDrag, switchBehaviour;
 @synthesize titlesArray, thumb, thumbRects, snapToIndex, trackingThumb, moved, activated, halfSize, dragOffset, segmentWidth, thumbHeight;
 
 // deprecated
@@ -78,6 +78,7 @@
         self.userInteractionEnabled = YES;
         self.animateToInitialSelection = NO;
         self.clipsToBounds = NO;
+		self.switchBehaviour = YES;
         
         self.font = [UIFont boldSystemFontOfSize:15];
         self.textColor = [UIColor grayColor];
@@ -320,9 +321,11 @@
 	CGFloat pMaxX = CGRectGetMaxX(self.bounds);
 	CGFloat pMinX = CGRectGetMinX(self.bounds);
 	
-	if(!self.moved && self.trackingThumb && [self.titlesArray count] == 2)
-		[self toggle];
 	
+	// If you don't want a UISwitch-like behaviour then set switchBehaviour to NO.
+	
+	if(!self.moved && self.trackingThumb && [self.titlesArray count] == 2 && self.switchBehaviour)
+		[self toggle];
 	else if(!self.activated && cPos.x > pMinX && cPos.x < pMaxX) {
 		self.snapToIndex = floor(cPos.x/self.segmentWidth);
 		[self snap:YES];


### PR DESCRIPTION
When you touch an already selected section, the default behaviour is to act like a UISwitch. In my app I don't want this, so I add a Bool property to deactivate this behaviour.
I've also updated the demo project.
