### PR TITLE
Slide only mode

### DIFF
--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -52,7 +52,8 @@
 	grayRC.height = 46;
 	
 	grayRC.thumb.tintColor = [UIColor colorWithRed:0 green:0.5 blue:0.1 alpha:1];
-	
+	grayRC.mustSlideToChange = YES;
+    
 	[self.view addSubview:grayRC];
 	
 	grayRC.center = CGPointMake(160, 270);

--- a/README.textile
+++ b/README.textile
@@ -45,6 +45,11 @@ SVSegmentedControl can be customized with the following properties:
 @property (nonatomic, readwrite) BOOL animateToInitialSelection; // default is NO
 @property (nonatomic, readwrite) BOOL crossFadeLabelsOnDrag; // default is NO
 
+// To make the control difficult to accidentally change, force the user to slide it
+@property (nonatomic, readwrite) BOOL mustSlideToChange; // default is NO
+// Only snap to a new segment if the thumb overlaps it by this fraction
+@property (nonatomic, readwrite) CGFloat minimumOverlapToChange; // default is 0.66
+
 @property (nonatomic, retain) UIColor *tintColor; // default is [UIColor grayColor]
 @property (nonatomic, retain) UIImage *backgroundImage; // default is nil
 

--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -25,6 +25,11 @@
 @property (nonatomic, readwrite) BOOL animateToInitialSelection; // default is NO
 @property (nonatomic, readwrite) BOOL crossFadeLabelsOnDrag; // default is NO
 
+// To make the control difficult to accidentally change, force the user to slide it
+@property (nonatomic, readwrite) BOOL mustSlideToChange; // default is NO
+// Only snap to a new segment if the thumb overlaps it by this fraction
+@property (nonatomic, readwrite) CGFloat minimumOverlapToChange; // default is 0.66
+
 @property (nonatomic, strong) UIColor *tintColor; // default is [UIColor grayColor]
 @property (nonatomic, strong) UIImage *backgroundImage; // default is nil
 

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -58,7 +58,7 @@
 
 @synthesize changeHandler, selectedIndex, animateToInitialSelection, accessibilityElements;
 @synthesize cornerRadius, tintColor, backgroundImage, font, textColor, textShadowColor, textShadowOffset, titleEdgeInsets, height, crossFadeLabelsOnDrag;
-@synthesize sectionTitles, sectionImages, thumb, thumbRects, snapToIndex, trackingThumb, moved, activated, halfSize, dragOffset, segmentWidth, thumbHeight;
+@synthesize sectionTitles, sectionImages, thumb, thumbRects, snapToIndex, trackingThumb, moved, activated, halfSize, dragOffset, segmentWidth, thumbHeight, thumbEdgeInset;
 
 #pragma mark -
 #pragma mark Life Cycle


### PR DESCRIPTION
Added suport for making the slider hard to accidentally change

Setting mustSlideToChange to YES will force the user to slide the thumb most of the way into the new section for it to change.
The value "most" defaults to two thirds of the way in, but is configurable with the CGFloat property "minimumOverlapToChange" (default 0.66).

Setting mustSlideToChange has 3 specific effects
1. the user must slide the thumb most of the way into the segment
2. tapping on a segment away from the thumb will not cause it to be selected
3. the toggle feature for 2-segment controls (where tapping anywhere will change the selection) is disabled
