### PR TITLE
Fixed exception when removing control from views

### DIFF
--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -119,6 +119,9 @@
 }
 
 - (void)willMoveToSuperview:(UIView *)newSuperview {
+    
+    if (newSuperview == nil) return; // control is being _removed_ from super view
+    
     int c = [self.sectionTitles count];
 	int i = 0;
 	


### PR DESCRIPTION
The willMoveToSuperview method used to layout the control when it is
added to its superview is also called with nil when being removed from
the superview. This sometimes lead to exception in the call
moveThumbToIndex ad the end of the method.
This fix merely returns from willMove when the newSuperView is nil.
