### PR TITLE
Fix ARC semantic error with `size`

### DIFF
--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -118,7 +118,7 @@
             CGFloat stringWidth = [titleString sizeWithFont:self.font].width+(self.titleEdgeInsets.left+self.titleEdgeInsets.right+self.thumbEdgeInset.left+self.thumbEdgeInset.right);
             
             if(self.sectionImages.count > i)
-                stringWidth+=[[self.sectionImages objectAtIndex:i] size].width+5;
+                stringWidth+=[(UIImage*)[self.sectionImages objectAtIndex:i] size].width+5;
             
             self.segmentWidth = MAX(stringWidth, self.segmentWidth);
             i++;


### PR DESCRIPTION
Hi, thanks for a great UI component!

I get an ARC semantic error when building this component (cloned clean from cocoapods) in Xcode 4.5.2.

This pull request fixes a semantic issue with multiple `size` methods by casting each sectionImages object to `UIImage`.
