### PR TITLE
Add light theme to control to allow use on lighter backgrounds.

### DIFF
--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -78,12 +78,39 @@
 	[self.view addSubview:yellowRC];
 	
 	yellowRC.center = CGPointMake(160, 370);
+    
+    // Light Control using new theme approach
+    UIView *lightBackground = [[UIView alloc] initWithFrame:CGRectMake(0, 400, 320, 160)];
+    lightBackground.backgroundColor = [UIColor colorWithWhite:0.75 alpha:1.0];
+    [self.view addSubview:lightBackground];
+	
+	SVSegmentedControl *lightRC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"One", @"Two", @"Three", nil] theme:SVSegmentedControlThemeLight];
+    [lightRC addTarget:self action:@selector(segmentedControlChangedValue:) forControlEvents:UIControlEventValueChanged];
+    
+	lightRC.crossFadeLabelsOnDrag = YES;
+	[self.view addSubview:lightRC];
+	
+	lightRC.center = CGPointMake(160, 430);
+    
+    // Light Control using existing tint color option
+    SVSegmentedControl *lightTintRC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"One", @"Two", @"Three", nil]];
+    [lightTintRC addTarget:self action:@selector(segmentedControlChangedValue:) forControlEvents:UIControlEventValueChanged];
+    
+	lightTintRC.crossFadeLabelsOnDrag = YES;
+    lightTintRC.tintColor = [UIColor colorWithWhite:0.9 alpha:1.0];
+    lightTintRC.thumb.tintColor = [UIColor colorWithWhite:0.6 alpha:1.0];
+	
+	[self.view addSubview:lightTintRC];
+	
+	lightTintRC.center = CGPointMake(160, 480);
 	
 	
 	navSC.tag = 1;
 	redSC.tag = 2;
 	grayRC.tag = 3;
 	yellowRC.tag = 4;
+   	lightRC.tag = 5;
+    lightTintRC.tag = 6;
 }
 
 

--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -12,6 +12,11 @@
 #import "SVSegmentedThumb.h"
 #import <AvailabilityMacros.h>
 
+enum {
+    SVSegmentedControlThemeDark,
+    SVSegmentedControlThemeLight,
+}typedef SVSegmentedControlTheme;
+
 @protocol SVSegmentedControlDelegate;
 
 @interface SVSegmentedControl : UIControl
@@ -43,6 +48,8 @@
 @property (nonatomic, readwrite) CGSize textShadowOffset;  // default is CGSizeMake(0, -1)
 
 - (SVSegmentedControl*)initWithSectionTitles:(NSArray*)titlesArray;
+- (SVSegmentedControl*)initWithSectionTitles:(NSArray *)array theme:(SVSegmentedControlTheme)theme;
+
 - (void)moveThumbToIndex:(NSUInteger)segmentIndex animate:(BOOL)animate DEPRECATED_ATTRIBUTE; // use setSelectedIndex:animated:
 - (void)setSelectedIndex:(NSUInteger)index animated:(BOOL)animated;
 

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -20,6 +20,8 @@
 @property (nonatomic, readonly) UIImageView *imageView;
 @property (nonatomic, readonly) UIImageView *secondImageView;
 
+- (id)initWithFrame:(CGRect)frame theme:(SVSegmentedControlTheme)theme;
+
 - (void)setTitle:(NSString*)title image:(UIImage*)image;
 - (void)setSecondTitle:(NSString*)title image:(UIImage*)image;
 
@@ -51,6 +53,8 @@
 @property (nonatomic, readwrite) CGFloat segmentWidth;
 @property (nonatomic, readwrite) CGFloat thumbHeight;
 
+@property (nonatomic, assign) SVSegmentedControlTheme theme;  // default is dark
+
 @end
 
 
@@ -67,7 +71,11 @@
 #pragma mark Life Cycle
 
 - (id)initWithSectionTitles:(NSArray*)array {
-    
+    return [self initWithSectionTitles:array theme:SVSegmentedControlThemeDark];
+}
+
+- (id)initWithSectionTitles:(NSArray *)array theme:(SVSegmentedControlTheme)theme {
+
 	if (self = [super initWithFrame:CGRectZero]) {
         self.sectionTitles = array;
         self.thumbRects = [NSMutableArray arrayWithCapacity:[array count]];
@@ -82,9 +90,21 @@
         self.mustSlideToChange = NO;
         self.minimumOverlapToChange = 0.66;
         
+        switch (theme) {
+            case SVSegmentedControlThemeDark:
+                self.textColor = [UIColor grayColor];
+                self.textShadowColor = [UIColor blackColor];
+                break;
+            case SVSegmentedControlThemeLight:
+                self.textColor = [UIColor colorWithWhite:0.3 alpha:1.0f];
+                self.textShadowColor = [UIColor whiteColor];
+                break;
+                
+            default:
+                break;
+        }
         self.font = [UIFont boldSystemFontOfSize:15];
-        self.textColor = [UIColor grayColor];
-        self.textShadowColor = [UIColor blackColor];
+        self.theme = theme;
         self.textShadowOffset = CGSizeMake(0, -1);
         
         self.titleEdgeInsets = UIEdgeInsetsMake(0, 10, 0, 10);
@@ -93,6 +113,7 @@
         self.cornerRadius = 4.0;
         
         self.selectedIndex = 0;
+        
         
         [self setupAccessibility];
     }
@@ -103,7 +124,7 @@
 - (SVSegmentedThumb *)thumb {
     
     if(thumb == nil)
-        thumb = [[SVSegmentedThumb alloc] initWithFrame:CGRectZero];
+        thumb = [[SVSegmentedThumb alloc] initWithFrame:CGRectZero theme:self.theme];
     
     return thumb;
 }
@@ -476,7 +497,6 @@
 
 #pragma mark - Drawing
 
-
 - (void)drawRect:(CGRect)rect {
     
     CGContextRef context = UIGraphicsGetCurrentContext();
@@ -499,8 +519,22 @@
         CGContextClip(context);
         
         // background tint
-        CGFloat components[4] = {0.10, CGColorGetAlpha(self.tintColor.CGColor),  0.12, CGColorGetAlpha(self.tintColor.CGColor)};
-        CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, components, NULL, 2);
+        CGGradientRef gradient;
+        switch (self.theme) {
+            case SVSegmentedControlThemeDark:{
+                CGFloat components[4] = {0.10, CGColorGetAlpha(self.tintColor.CGColor),  0.12, CGColorGetAlpha(self.tintColor.CGColor)};
+                gradient = CGGradientCreateWithColorComponents(colorSpace, components, NULL, 2);
+                break;
+            }
+            case SVSegmentedControlThemeLight:{
+                CGFloat components[4] = {0.90, CGColorGetAlpha(self.tintColor.CGColor),  0.93, CGColorGetAlpha(self.tintColor.CGColor)};
+                gradient = CGGradientCreateWithColorComponents(colorSpace, components, NULL, 2);
+                break;
+            }
+                
+            default:
+                break;
+        }
         CGContextDrawLinearGradient(context, gradient, CGPointMake(0,0), CGPointMake(0,CGRectGetHeight(rect)-1), 0);
         CGGradientRelease(gradient);
         CGColorSpaceRelease(colorSpace);

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -543,7 +543,19 @@
         UIRectFillUsingBlendMode(rect, kCGBlendModeOverlay);
         
         
-        UIColor *innerShadowColor = [UIColor colorWithWhite:0 alpha:0.8];
+        UIColor *innerShadowColor;
+        switch (self.theme) {
+            case SVSegmentedControlThemeDark:
+                innerShadowColor = [UIColor colorWithWhite:0 alpha:0.8];
+                break;
+            case SVSegmentedControlThemeLight:
+                innerShadowColor = [UIColor colorWithWhite:0.4 alpha:0.8];
+                break;
+                
+            default:
+                break;
+        }
+
         NSArray *paths = [NSArray arrayWithObject:[UIBezierPath bezierPathWithRoundedRect:insetRect cornerRadius:self.cornerRadius]];
         UIImage *mask = [self maskWithPaths:paths bounds:CGRectInset(insetRect, -10, -10)];
         UIImage *invertedImage = [self invertedImageWithMask:mask color:innerShadowColor];

--- a/SVSegmentedControl/SVSegmentedThumb.m
+++ b/SVSegmentedControl/SVSegmentedThumb.m
@@ -238,8 +238,8 @@
                 secondColorComponent = 0.35;
                 break;
             case SVSegmentedControlThemeLight:
-                firstColorComponent = 0.8;
-                secondColorComponent = 0.65;
+                firstColorComponent = 0.7;
+                secondColorComponent = 0.55;
                 break;
             default:
                 break;

--- a/SVSegmentedControl/SVSegmentedThumb.m
+++ b/SVSegmentedControl/SVSegmentedThumb.m
@@ -26,6 +26,7 @@
 
 @property (nonatomic, readonly) BOOL isAtLastIndex;
 @property (nonatomic, readonly) BOOL isAtFirstIndex;
+@property (nonatomic, assign) SVSegmentedControlTheme theme;
 
 - (void)activate;
 - (void)deactivate;
@@ -42,6 +43,29 @@
 @synthesize secondImageView = _secondImageView;
 @synthesize thumbBackgroundImageView = _thumbBackgroundImageView;
 
+- (id)initWithFrame:(CGRect)frame theme:(SVSegmentedControlTheme)theme {
+    self = [self initWithFrame:frame];
+    if (self) {
+        self.theme = theme;
+        switch (theme) {
+            case SVSegmentedControlThemeDark:
+                self.textColor = [UIColor whiteColor];
+                self.textShadowColor = [UIColor blackColor];
+                self.tintColor = [UIColor grayColor];                
+                break;
+            case SVSegmentedControlThemeLight:
+                self.textColor = [UIColor colorWithWhite:0 alpha:1.0];
+                self.textShadowColor = [UIColor colorWithWhite:1.0 alpha:1];
+                self.tintColor = [UIColor colorWithWhite:0.7 alpha:1.0];
+                break;
+            
+            default:
+                break;
+        }
+    }
+    return self;
+}
+
 - (id)initWithFrame:(CGRect)frame {
     
     self = [super initWithFrame:frame];
@@ -50,10 +74,7 @@
 		self.userInteractionEnabled = NO;
         self.clipsToBounds = YES;
 		self.backgroundColor = [UIColor clearColor];
-		self.textColor = [UIColor whiteColor];
-		self.textShadowColor = [UIColor blackColor];
 		self.textShadowOffset = CGSizeMake(0, -1);
-		self.tintColor = [UIColor grayColor];
         self.shouldCastShadow = YES;
         self.backgroundColor = [UIColor clearColor];
     }
@@ -209,7 +230,22 @@
         CGContextSaveGState(context);
         CGContextClip(context);
         
-        CGFloat fillComponents[4] = {0.5, CGColorGetAlpha(self.tintColor.CGColor),   0.35, CGColorGetAlpha(self.tintColor.CGColor)};
+        CGFloat firstColorComponent;
+        CGFloat secondColorComponent;
+        switch (self.theme) {
+            case SVSegmentedControlThemeDark:
+                firstColorComponent = 0.5;
+                secondColorComponent = 0.35;
+                break;
+            case SVSegmentedControlThemeLight:
+                firstColorComponent = 0.8;
+                secondColorComponent = 0.65;
+                break;
+            default:
+                break;
+        }
+        
+        CGFloat fillComponents[4] = {firstColorComponent, CGColorGetAlpha(self.tintColor.CGColor),   secondColorComponent, CGColorGetAlpha(self.tintColor.CGColor)};
         
         if(self.selected) {
             fillComponents[0]-=0.1;


### PR DESCRIPTION
I added a theme to the initializer so the control can be used on lighter backgrounds.  I added 2 examples to the demo app showing the existing tintColor approach and another one with the light theme.  We're using this control on a light grey background so we decided to use this approach rather than providing a separate background image.

-JG
ps. Thanks for the wicked control.
