### PR TITLE
Improve background tintColor

### DIFF
--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -78,6 +78,24 @@
 	[self.view addSubview:yellowRC];
 	
 	yellowRC.center = CGPointMake(160, 370);
+    
+    // Light Backgrounds
+    UIView *background = [[UIView alloc] initWithFrame:CGRectMake(0, 400, 320, 160)];
+    background.backgroundColor = [UIColor colorWithWhite:0.8 alpha:1];
+    [self.view addSubview:background];
+    SVSegmentedControl *tintSC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Section 1", @"Section 2", nil]];
+
+	[self.view addSubview:tintSC];
+    tintSC.tintColor = [UIColor colorWithWhite:0.9 alpha:1];
+    tintSC.thumb.tintColor = [UIColor colorWithWhite:0.9 alpha:1.0];
+    tintSC.thumb.textColor = [UIColor blackColor];
+    tintSC.thumb.textShadowColor = [UIColor whiteColor];
+    tintSC.thumb.gradientIntensity = 0.075;
+    tintSC.textColor = [UIColor colorWithWhite:0.3 alpha:1];
+    tintSC.textShadowColor = [UIColor whiteColor];
+    tintSC.innerShadowColor = [UIColor colorWithWhite:0.4 alpha:0.8];
+	tintSC.center = CGPointMake(160, 450);
+
 	
 	
 	navSC.tag = 1;

--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -83,9 +83,9 @@
     UIView *background = [[UIView alloc] initWithFrame:CGRectMake(0, 400, 320, 160)];
     background.backgroundColor = [UIColor colorWithWhite:0.8 alpha:1];
     [self.view addSubview:background];
-    SVSegmentedControl *tintSC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Section 1", @"Section 2", nil]];
-
-	[self.view addSubview:tintSC];
+    
+    // Using Deprecated tintColor property
+    SVSegmentedControl *tintSC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Sec1", @"Sec2", nil]];
     tintSC.tintColor = [UIColor colorWithWhite:0.9 alpha:1];
     tintSC.thumb.tintColor = [UIColor colorWithWhite:0.9 alpha:1.0];
     tintSC.thumb.textColor = [UIColor blackColor];
@@ -94,19 +94,41 @@
     tintSC.textColor = [UIColor colorWithWhite:0.3 alpha:1];
     tintSC.textShadowColor = [UIColor whiteColor];
     tintSC.innerShadowColor = [UIColor colorWithWhite:0.4 alpha:0.8];
-	tintSC.center = CGPointMake(160, 450);
-
-    SVSegmentedControl *tintSC2 = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Section 1", @"Section 2", nil]];
-    
+	tintSC.center = CGPointMake(90, 440);
 	[self.view addSubview:tintSC];
+
+    SVSegmentedControl *tintSC2 = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Sec1", @"Sec2", nil]];
     tintSC2.tintColor = [UIColor colorWithRed:0.647 green:1.000 blue:0.247 alpha:1.000];
     tintSC2.thumb.tintColor = [UIColor colorWithWhite:0.9 alpha:1.0];
     tintSC2.thumb.textColor = [UIColor blackColor];
     tintSC2.thumb.textShadowColor = [UIColor whiteColor];
     tintSC2.textColor = [UIColor colorWithWhite:0.3 alpha:1];
     tintSC2.textShadowColor = [UIColor whiteColor];
-	tintSC2.center = CGPointMake(160, 500);
+	tintSC2.center = CGPointMake(90, 500);
     [self.view addSubview:tintSC2];
+    
+    // Using New backgroundTintColor property
+    SVSegmentedControl *backgroundTintSC = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Sec1", @"Sec2", nil]];
+    backgroundTintSC.backgroundTintColor = [UIColor colorWithWhite:0.9 alpha:1];
+    backgroundTintSC.thumb.tintColor = [UIColor colorWithWhite:0.9 alpha:1.0];
+    backgroundTintSC.thumb.textColor = [UIColor blackColor];
+    backgroundTintSC.thumb.textShadowColor = [UIColor whiteColor];
+    backgroundTintSC.thumb.gradientIntensity = 0.075;
+    backgroundTintSC.textColor = [UIColor colorWithWhite:0.3 alpha:1];
+    backgroundTintSC.textShadowColor = [UIColor whiteColor];
+    backgroundTintSC.innerShadowColor = [UIColor colorWithWhite:0.4 alpha:0.8];
+	backgroundTintSC.center = CGPointMake(230, 440);
+	[self.view addSubview:backgroundTintSC];
+    
+    SVSegmentedControl *backgroundTintSC2 = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Sec1", @"Sec2", nil]];
+    backgroundTintSC2.backgroundTintColor = [UIColor colorWithRed:0.647 green:1.000 blue:0.247 alpha:1.000];
+    backgroundTintSC2.thumb.tintColor = [UIColor colorWithWhite:0.9 alpha:1.0];
+    backgroundTintSC2.thumb.textColor = [UIColor blackColor];
+    backgroundTintSC2.thumb.textShadowColor = [UIColor whiteColor];
+    backgroundTintSC2.textColor = [UIColor colorWithWhite:0.3 alpha:1];
+    backgroundTintSC2.textShadowColor = [UIColor whiteColor];
+	backgroundTintSC2.center = CGPointMake(230, 500);
+    [self.view addSubview:backgroundTintSC2];
 	
 	navSC.tag = 1;
 	redSC.tag = 2;

--- a/Demo/Classes/ViewController.m
+++ b/Demo/Classes/ViewController.m
@@ -96,7 +96,17 @@
     tintSC.innerShadowColor = [UIColor colorWithWhite:0.4 alpha:0.8];
 	tintSC.center = CGPointMake(160, 450);
 
-	
+    SVSegmentedControl *tintSC2 = [[SVSegmentedControl alloc] initWithSectionTitles:[NSArray arrayWithObjects:@"Section 1", @"Section 2", nil]];
+    
+	[self.view addSubview:tintSC];
+    tintSC2.tintColor = [UIColor colorWithRed:0.647 green:1.000 blue:0.247 alpha:1.000];
+    tintSC2.thumb.tintColor = [UIColor colorWithWhite:0.9 alpha:1.0];
+    tintSC2.thumb.textColor = [UIColor blackColor];
+    tintSC2.thumb.textShadowColor = [UIColor whiteColor];
+    tintSC2.textColor = [UIColor colorWithWhite:0.3 alpha:1];
+    tintSC2.textShadowColor = [UIColor whiteColor];
+	tintSC2.center = CGPointMake(160, 500);
+    [self.view addSubview:tintSC2];
 	
 	navSC.tag = 1;
 	redSC.tag = 2;

--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -41,6 +41,7 @@
 @property (nonatomic, strong) UIColor *textColor; // default is [UIColor grayColor];
 @property (nonatomic, strong) UIColor *textShadowColor;  // default is [UIColor blackColor]
 @property (nonatomic, readwrite) CGSize textShadowOffset;  // default is CGSizeMake(0, -1)
+@property (nonatomic, strong) UIColor *innerShadowColor; // default is [UIColor colorWithWhite:0 alpha:0.8]
 
 - (SVSegmentedControl*)initWithSectionTitles:(NSArray*)titlesArray;
 - (void)moveThumbToIndex:(NSUInteger)segmentIndex animate:(BOOL)animate DEPRECATED_ATTRIBUTE; // use setSelectedIndex:animated:

--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -29,7 +29,8 @@
 @property (nonatomic, readwrite) CGFloat minimumOverlapToChange; // default is 0.66 - Only snap to a new segment if the thumb overlaps it by this fraction
 @property (nonatomic, readwrite) UIEdgeInsets touchTargetMargins; // default is UIEdgeInsetsMake(0, 0, 0, 0) - Enlarge touch target of control
 
-@property (nonatomic, strong) UIColor *tintColor; // default is [UIColor grayColor]
+@property (nonatomic, strong) UIColor *backgroundTintColor; // default is [UIColor colorWithWhite:0.1 alpha:1]
+@property (nonatomic, strong) UIColor *tintColor __attribute__((deprecated("use 'backgroundTintColor'"))); // default is [UIColor grayColor]
 @property (nonatomic, strong) UIImage *backgroundImage; // default is nil
 
 @property (nonatomic, readwrite) CGFloat height; // default is 32.0

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -57,7 +57,7 @@
 @implementation SVSegmentedControl
 
 @synthesize changeHandler, animateToInitialSelection, accessibilityElements;
-@synthesize cornerRadius, tintColor, backgroundImage, font, textColor, textShadowColor, textShadowOffset, titleEdgeInsets, height, crossFadeLabelsOnDrag;
+@synthesize cornerRadius, tintColor, backgroundTintColor, backgroundImage, font, textColor, textShadowColor, textShadowOffset, titleEdgeInsets, height, crossFadeLabelsOnDrag;
 @synthesize sectionTitles, sectionImages, thumb, thumbRects, snapToIndex, trackingThumb, moved, activated, halfSize, dragOffset, segmentWidth, thumbHeight, thumbEdgeInset;
 @synthesize mustSlideToChange, minimumOverlapToChange, touchTargetMargins;
 
@@ -74,7 +74,7 @@
         self.accessibilityElements = [NSMutableArray arrayWithCapacity:self.sectionTitles.count];
         
         self.backgroundColor = [UIColor clearColor];
-        self.tintColor = [UIColor colorWithWhite:0.1 alpha:1];
+        self.backgroundTintColor = [UIColor colorWithWhite:0.1 alpha:1];
         self.clipsToBounds = YES;
         self.userInteractionEnabled = YES;
         self.animateToInitialSelection = NO;
@@ -501,13 +501,18 @@
         CGContextClip(context);
         
         // background tint
-        CGFloat components[4] = {0.45, CGColorGetAlpha(self.tintColor.CGColor),  0.47, CGColorGetAlpha(self.tintColor.CGColor)};
+        CGFloat firstComponent = tintColor ? 0.10 : 0.45;
+        CGFloat secondComponent = tintColor ? 0.12 : 0.47;
+        
+        UIColor *tintColorToApply = tintColor ? tintColor : backgroundTintColor;
+        
+        CGFloat components[4] = {firstComponent, CGColorGetAlpha(tintColorToApply.CGColor),  secondComponent, CGColorGetAlpha(tintColorToApply.CGColor)};
         CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, components, NULL, 2);
         CGContextDrawLinearGradient(context, gradient, CGPointMake(0,0), CGPointMake(0,CGRectGetHeight(rect)-1), 0);
         CGGradientRelease(gradient);
         CGColorSpaceRelease(colorSpace);
         
-        [self.tintColor set];
+        [tintColorToApply set];
         UIRectFillUsingBlendMode(rect, kCGBlendModeOverlay);
         
         NSArray *paths = [NSArray arrayWithObject:[UIBezierPath bezierPathWithRoundedRect:insetRect cornerRadius:self.cornerRadius]];

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -74,7 +74,7 @@
         self.accessibilityElements = [NSMutableArray arrayWithCapacity:self.sectionTitles.count];
         
         self.backgroundColor = [UIColor clearColor];
-        self.tintColor = [UIColor grayColor];
+        self.tintColor = [UIColor colorWithWhite:0.1 alpha:1];
         self.clipsToBounds = YES;
         self.userInteractionEnabled = YES;
         self.animateToInitialSelection = NO;
@@ -93,6 +93,8 @@
         self.cornerRadius = 4.0;
         
         self.selectedIndex = 0;
+        
+        self.innerShadowColor = [UIColor colorWithWhite:0 alpha:0.8];
         
         [self setupAccessibility];
     }
@@ -499,7 +501,7 @@
         CGContextClip(context);
         
         // background tint
-        CGFloat components[4] = {0.10, CGColorGetAlpha(self.tintColor.CGColor),  0.12, CGColorGetAlpha(self.tintColor.CGColor)};
+        CGFloat components[4] = {0.45, CGColorGetAlpha(self.tintColor.CGColor),  0.47, CGColorGetAlpha(self.tintColor.CGColor)};
         CGGradientRef gradient = CGGradientCreateWithColorComponents(colorSpace, components, NULL, 2);
         CGContextDrawLinearGradient(context, gradient, CGPointMake(0,0), CGPointMake(0,CGRectGetHeight(rect)-1), 0);
         CGGradientRelease(gradient);
@@ -508,13 +510,11 @@
         [self.tintColor set];
         UIRectFillUsingBlendMode(rect, kCGBlendModeOverlay);
         
-        
-        UIColor *innerShadowColor = [UIColor colorWithWhite:0 alpha:0.8];
         NSArray *paths = [NSArray arrayWithObject:[UIBezierPath bezierPathWithRoundedRect:insetRect cornerRadius:self.cornerRadius]];
         UIImage *mask = [self maskWithPaths:paths bounds:CGRectInset(insetRect, -10, -10)];
-        UIImage *invertedImage = [self invertedImageWithMask:mask color:innerShadowColor];
+        UIImage *invertedImage = [self invertedImageWithMask:mask color:self.innerShadowColor];
         
-        CGContextSetShadowWithColor(context, CGSizeMake(0, 1), 2, innerShadowColor.CGColor);
+        CGContextSetShadowWithColor(context, CGSizeMake(0, 1), 2, self.innerShadowColor.CGColor);
         [invertedImage drawAtPoint:CGPointMake(-10, -10)];
         
     }

--- a/SVSegmentedControl/SVSegmentedThumb.h
+++ b/SVSegmentedControl/SVSegmentedThumb.h
@@ -22,5 +22,6 @@
 @property (nonatomic, strong) UIColor *textShadowColor; // default is [UIColor blackColor]
 @property (nonatomic, readwrite) CGSize textShadowOffset; // default is CGSizeMake(0, -1)
 @property (nonatomic, readwrite) BOOL shouldCastShadow; // default is YES (NO when backgroundImage is set)
+@property (nonatomic, assign) CGFloat gradientIntensity; // default is 0.15
 
 @end

--- a/SVSegmentedControl/SVSegmentedThumb.m
+++ b/SVSegmentedControl/SVSegmentedThumb.m
@@ -56,6 +56,7 @@
 		self.tintColor = [UIColor grayColor];
         self.shouldCastShadow = YES;
         self.backgroundColor = [UIColor clearColor];
+        self.gradientIntensity = 0.15;
     }
 	
     return self;
@@ -209,7 +210,8 @@
         CGContextSaveGState(context);
         CGContextClip(context);
         
-        CGFloat fillComponents[4] = {0.5, CGColorGetAlpha(self.tintColor.CGColor),   0.35, CGColorGetAlpha(self.tintColor.CGColor)};
+        CGFloat gradientStart = 0.5;
+        CGFloat fillComponents[4] = {gradientStart, CGColorGetAlpha(self.tintColor.CGColor),   gradientStart-self.gradientIntensity, CGColorGetAlpha(self.tintColor.CGColor)};
         
         if(self.selected) {
             fillComponents[0]-=0.1;


### PR DESCRIPTION
When we originally tried to change the control tintColor we couldn't get it to go light enough for a light background.  It also didn't let any actual tint colors shine through.

Before:
![iOS Simulator Screen shot 2013-03-16 7 44 51 PM](https://f.cloud.github.com/assets/1066132/267515/840fd2f2-8e93-11e2-9981-b72a9bcc16b0.png)

The gradient colors on the background components were too close to black - overriding any tintColor options.  This pull request moves those close to a middle grey, as well as changes the default tintColor to match the existing controls in the demo.  It also includes an option to customize the intensity of the gradient on the thumb.  In lighter scenarios, the gradient seemed too much.  

After:
![iOS Simulator Screen shot 2013-03-16 7 44 22 PM](https://f.cloud.github.com/assets/1066132/267516/87744a22-8e93-11e2-820b-baa0fb37f9e1.png)

JG
Thanks for making me look at this again. This is much more elegant than the other way!
=)
