### PR TITLE
Change NSArray properties to copy ownership.

### DIFF
--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -17,8 +17,8 @@
 @interface SVSegmentedControl : UIControl
 
 @property (nonatomic, copy) void (^changeHandler)(NSUInteger newIndex); // you can also use addTarget:action:forControlEvents:
-@property (nonatomic, strong) NSArray *sectionTitles;
-@property (nonatomic, strong) NSArray *sectionImages;
+@property (nonatomic, copy) NSArray *sectionTitles;
+@property (nonatomic, copy) NSArray *sectionImages;
 
 @property (nonatomic, strong, readonly) SVSegmentedThumb *thumb;
 @property (nonatomic, readonly) NSUInteger selectedSegmentIndex; // default is 0

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -449,7 +449,7 @@
 - (void)setSectionTitles:(NSArray *)sectionTitles
 {
     if (_sectionTitles != sectionTitles) {
-        _sectionTitles = sectionTitles;
+        _sectionTitles = [sectionTitles copy];
         if (self.selectedSegmentIndex < _sectionTitles.count) {
             
         } else {


### PR DESCRIPTION
Also, changed setSectionTitles: to copy the new sectionTitles into the _sectionTitles ivar.

Note: Considered removing the `if (_sectionTitles != sectionTitles)` wrap from setSectionTitles:, as it's no longer needed (unless someone does a `self.sectionTitles = _sectionTitles`, which is unlikely).  However, this could to unwanted side-effects since setNeedsDisplay/setupAccessibility would still get run even though no values have changed.  As such, it's probably safer to just leave it in.
