### PR TITLE
Make selectedSegmentIndex a publicly readwrite property

### DIFF
--- a/SVSegmentedControl/SVSegmentedControl.h
+++ b/SVSegmentedControl/SVSegmentedControl.h
@@ -21,7 +21,7 @@
 @property (nonatomic, copy) NSArray *sectionImages;
 
 @property (nonatomic, strong, readonly) SVSegmentedThumb *thumb;
-@property (nonatomic, readonly) NSUInteger selectedSegmentIndex; // default is 0
+@property (nonatomic, readwrite) NSUInteger selectedSegmentIndex; // default is 0
 @property (nonatomic, readwrite) BOOL animateToInitialSelection; // default is NO
 @property (nonatomic, readwrite) BOOL crossFadeLabelsOnDrag; // default is NO
 

--- a/SVSegmentedControl/SVSegmentedControl.m
+++ b/SVSegmentedControl/SVSegmentedControl.m
@@ -42,7 +42,6 @@
 @property (nonatomic, strong) NSMutableArray *thumbRects;
 @property (nonatomic, strong) NSMutableArray *accessibilityElements;
 
-@property (nonatomic, readwrite) NSUInteger selectedSegmentIndex;
 @property (nonatomic, readwrite) NSUInteger snapToIndex;
 @property (nonatomic, readwrite) BOOL trackingThumb;
 @property (nonatomic, readwrite) BOOL moved;


### PR DESCRIPTION
To:
- Better mimic a `UISegmentControl` (like #41 did for the property name).
- Do like most `UIKit` classes do with two setters, one with `animated:` parameter and one without (which fallbacks to no animation).
- Simpler syntax when no animation is desired.
